### PR TITLE
[EPPETA-48] - CreatedDate and LastModifiedDate fields populating correctly on database

### DIFF
--- a/src/webapi/Evaluations/Data/EvaluationDbContext.cs
+++ b/src/webapi/Evaluations/Data/EvaluationDbContext.cs
@@ -298,16 +298,32 @@ namespace eppeta.webapi.Evaluations.Data
             base.OnModelCreating(modelBuilder);
             modelBuilder.HasDefaultSchema("eppeta");
             modelBuilder.Entity<Status>().ToTable(nameof(Status));
-            modelBuilder.Entity<Evaluation>().ToTable(nameof(Evaluation));
-            modelBuilder.Entity<EvaluationObjective>().ToTable(nameof(EvaluationObjective));
-            modelBuilder.Entity<EvaluationElement>().ToTable(nameof(EvaluationElement));
-            modelBuilder.Entity<PerformanceEvaluation>().ToTable(nameof(PerformanceEvaluation));
-            modelBuilder.Entity<PerformanceEvaluationRating>().ToTable(nameof(PerformanceEvaluationRating));
+
+            modelBuilder.Entity<Evaluation>().ToTable(nameof(Evaluation)).Property(e => e.CreateDate).HasDefaultValueSql("getdate()");
+            modelBuilder.Entity<Evaluation>().Property(e => e.LastModifiedDate).HasDefaultValueSql("getdate()");
+
+            modelBuilder.Entity<EvaluationObjective>().ToTable(nameof(EvaluationObjective)).Property(e => e.CreateDate).HasDefaultValueSql("getdate()");
+            modelBuilder.Entity<EvaluationObjective>().Property(e => e.LastModifiedDate).HasDefaultValueSql("getdate()");
+
+            modelBuilder.Entity<EvaluationElement>().ToTable(nameof(EvaluationElement)).Property(x => x.CreateDate).HasDefaultValueSql("getdate()");
+            modelBuilder.Entity<EvaluationElement>().Property(x => x.LastModifiedDate).HasDefaultValueSql("getdate()");
+
+            modelBuilder.Entity<PerformanceEvaluation>().ToTable(nameof(PerformanceEvaluation)).Property(x => x.CreateDate).HasDefaultValueSql("getdate()");
+            modelBuilder.Entity<PerformanceEvaluation>().Property(x => x.LastModifiedDate).HasDefaultValueSql("getdate()");
+
+            modelBuilder.Entity<PerformanceEvaluationRating>().ToTable(nameof(PerformanceEvaluationRating)).Property(x => x.CreateDate).HasDefaultValueSql("getdate()");
+
             modelBuilder.Entity<PerformanceEvaluationRatingLevel>().ToTable(nameof(PerformanceEvaluationRatingLevel));
-            modelBuilder.Entity<EvaluationRating>().ToTable(nameof(EvaluationRating));
-            modelBuilder.Entity<EvaluationObjectiveRating>().ToTable(nameof(EvaluationObjectiveRating));
-            modelBuilder.Entity<EvaluationElementRating>().ToTable(nameof(EvaluationElementRating));
-            modelBuilder.Entity<EvaluationElementRatingResult>().ToTable(nameof(EvaluationElementRatingResult));
+
+            modelBuilder.Entity<EvaluationRating>().ToTable(nameof(EvaluationRating)).Property(x => x.CreateDate).HasDefaultValueSql("getdate()");
+            modelBuilder.Entity<EvaluationRating>().Property(x => x.LastModifiedDate).HasDefaultValueSql("getdate()");
+
+            modelBuilder.Entity<EvaluationObjectiveRating>().ToTable(nameof(EvaluationObjectiveRating)).Property(x => x.CreateDate).HasDefaultValueSql("getdate()");
+            modelBuilder.Entity<EvaluationObjectiveRating>().Property(x => x.LastModifiedDate).HasDefaultValueSql("getdate()");
+
+            modelBuilder.Entity<EvaluationElementRating>().ToTable(nameof(EvaluationElementRating)).Property(e => e.CreateDate).HasDefaultValueSql("getdate()");
+
+            modelBuilder.Entity<EvaluationElementRatingResult>().ToTable(nameof(EvaluationElementRatingResult)).Property(e => e.CreateDate).HasDefaultValueSql("getdate()");
 
             // Configure the Many-to-one relationship between PerformedEvaluation and ApplicationUser
             // Reference the ApplicationUser property in PerformedEvaluation


### PR DESCRIPTION
The problem was that, since these 2 fields are required, when the entity class is instantiated, the framework assigns the default value, which is what you see in the database. So, on this context, since these values are not null when the database receives them, the constraints don't work. 