### PR TITLE
EPPETA-67 Cleanup CodeQL/GitHub code warnings

### DIFF
--- a/.github/workflows/on-pullrequest-cs.yml
+++ b/.github/workflows/on-pullrequest-cs.yml
@@ -6,6 +6,9 @@
 name: On Pull Request - C#
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - main
@@ -29,7 +32,7 @@ jobs:
         shell: pwsh
     steps:
       - name: Checkout the Repo
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Setup .NET
         uses: actions/setup-dotnet@607fce577a46308457984d59e4954e075820f10a # v3.0.3
@@ -37,11 +40,11 @@ jobs:
           global-json-file: src/global.json
 
       - name: Dependency Review ("Dependabot on PR")
-        uses: actions/dependency-review-action@c090f4e553673e6e505ea70d6a95362ee12adb94 # v3.0.3
+        uses: actions/dependency-review-action@7bbfa034e752445ea40215fff1c3bf9597993d3f # v3.1.3
 
       - name: Initialize CodeQL
         if: success()
-        uses: github/codeql-action/init@896079047b4bb059ba6f150a5d87d47dde99e6e5 # codeql-bundle-20221211
+        uses: github/codeql-action/init@df32e399139a3050671466d7d9b3cbacc1cfd034 # codeql-bundle-v2.15.2
         with:
           languages: csharp
 
@@ -53,7 +56,7 @@ jobs:
 
       - name: Perform CodeQL Analysis
         if: success()
-        uses: github/codeql-action/analyze@896079047b4bb059ba6f150a5d87d47dde99e6e5 # codeql-bundle-20221211
+        uses: github/codeql-action/analyze@df32e399139a3050671466d7d9b3cbacc1cfd034 # codeql-bundle-v2.15.2
 
       - name: Run Unit Tests
         if: success()
@@ -67,7 +70,7 @@ jobs:
         run: dotnet test eppeta.webapi.unitTests --logger "trx;LogFileName=unit-tests.trx" --nologo
 
       - name: Upload Test Results
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         if: always()
         with:
           name: csharp-tests

--- a/.github/workflows/on-pullrequest-react.yml
+++ b/.github/workflows/on-pullrequest-react.yml
@@ -6,6 +6,9 @@
 name: On Pull Request - React
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - main
@@ -24,10 +27,10 @@ jobs:
         shell: bash
     steps:
       - name: Checkout the Repo
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Setup Node
-        uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # v3.5.1
+        uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65 # v4.0.0
         with:
           node-version: "16"
           cache: "npm"
@@ -35,7 +38,7 @@ jobs:
 
       - name: Node modules cache
         id: modules-cache
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 #v3.0.11
+        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 #v3.3.2
         with:
           path: "**/node_modules"
           key: ${{ runner.os }}-modules-${{ hashFiles('**/package-lock.json') }}
@@ -55,11 +58,11 @@ jobs:
           npm run build
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@896079047b4bb059ba6f150a5d87d47dde99e6e5 # v2.11.6
+        uses: github/codeql-action/init@df32e399139a3050671466d7d9b3cbacc1cfd034 # codeql-bundle-v2.15.2
         with:
           languages: "javascript"
           setup-python-dependencies: false
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@896079047b4bb059ba6f150a5d87d47dde99e6e5 # v2.11.6
+        uses: github/codeql-action/analyze@df32e399139a3050671466d7d9b3cbacc1cfd034 # codeql-bundle-v2.15.2
 


### PR DESCRIPTION
Upgrade actions.
PS. .NET warnings were fixed on EPPETA-69
Add an on push (main)