### PR TITLE
[EPPETA-40] Add authorization attributes to apropriate calls or controllers

### DIFF
--- a/sql/mssql/00002-Create-UserTables.sql
+++ b/sql/mssql/00002-Create-UserTables.sql
@@ -128,7 +128,7 @@ GO
 
 
 INSERT INTO [eppeta].[Roles] ([Id], [Name], [NormalizedName])
-VALUES ('1', 'Administrator', 'ADMINISTRATOR'), ('2', 'Supervisor', 'SUPERVISOR'), ('3', 'Mentor Teacher', 'MENTOR TEACHER');
+VALUES ('1', 'Administrator', 'ADMINISTRATOR'), ('2', 'Reviewer', 'REVIEWER'), ('3', 'Evaluator', 'Evaluator');
 GO
 
 

--- a/src/reactapp/src/App.js
+++ b/src/reactapp/src/App.js
@@ -25,9 +25,9 @@ function App() {
         <Route path="/" element={<LoginForm />} />
         <Route path="/signup" element={<SignupForm />} />
         <Route path="/login" element={<LoginForm />} />
-        <Route path="/main" element={<AuthenticatedRoute roles={[ApplicationRoles.Mentor, ApplicationRoles.Supervisor]}  element={<EvaluationTable />} />} />
-        <Route path="/new" element={<AuthenticatedRoute roles={[ApplicationRoles.Mentor, ApplicationRoles.Supervisor]} element={<NewEvaluation />} />} />
-        <Route path="/evaluation/:id?" element={<AuthenticatedRoute roles={[ApplicationRoles.Mentor, ApplicationRoles.Supervisor]} element={<EvaluationForm />} />} />
+        <Route path="/main" element={<AuthenticatedRoute roles={[ApplicationRoles.Evaluator, ApplicationRoles.Reviewer]}  element={<EvaluationTable />} />} />
+        <Route path="/new" element={<AuthenticatedRoute roles={[ApplicationRoles.Evaluator, ApplicationRoles.Reviewer]} element={<NewEvaluation />} />} />
+        <Route path="/evaluation/:id?" element={<AuthenticatedRoute roles={[ApplicationRoles.Evaluator, ApplicationRoles.Reviewer]} element={<EvaluationForm />} />} />
         <Route path="/users" element={<AuthenticatedRoute roles={[ApplicationRoles.Administrator]} element={<UserListTable />} />} />
         <Route path="/userProfile/:id?" element={<AuthenticatedRoute roles={[ApplicationRoles.Administrator]} element={<UserProfile />} />} />
       </Routes>

--- a/src/reactapp/src/components/Navbar.js
+++ b/src/reactapp/src/components/Navbar.js
@@ -34,7 +34,7 @@ import { ApplicationRoles } from "../constants";
 
 export const getHomePageByRole = () => {
   if (getLoggedInUserName()) {
-    if (isLoggedInUserInRole([ApplicationRoles.Mentor, ApplicationRoles.Supervisor])) {
+    if (isLoggedInUserInRole([ApplicationRoles.Evaluator, ApplicationRoles.Reviewer])) {
       return "/main";
     }
     else if (isLoggedInUserInRole([ApplicationRoles.Administrator])) {

--- a/src/reactapp/src/constants.js
+++ b/src/reactapp/src/constants.js
@@ -1,5 +1,5 @@
 export const ApplicationRoles = {
   Administrator: 'Administrator',
-  Mentor: 'Mentor Teacher',
-  Supervisor: 'Supervisor'
+  Evaluator: 'Evaluator',
+  Reviewer: 'Reviewer'
 };

--- a/src/reactapp/src/pages/EvaluationForm.js
+++ b/src/reactapp/src/pages/EvaluationForm.js
@@ -615,7 +615,7 @@ export default function EvaluationForm() {
         else {
           return;
         }
-        if (id && !isLoggedInUserInRole([ApplicationRoles.Supervisor]) && page_session_data.userId !== getLoggedInUserId()) {
+        if (id && !isLoggedInUserInRole([ApplicationRoles.Reviewer]) && page_session_data.userId !== getLoggedInUserId()) {
           setAlertMessageText("You do not have access to the evaluation");
           setUserHasAccessToEvaluation(false);
           return;
@@ -840,7 +840,7 @@ export default function EvaluationForm() {
             <ButtonGroup variant="outline" spacing="6">
               <AlertMessageDialog showIcon="warning" buttonDisabled={ !areAllScoreSelected() } alertTitle="Save Evaluation" buttonColorScheme="blue" buttonText="Save" message="Are you sure you want to save the evaluation?" onYes={() => { saveEvaluation() }}></AlertMessageDialog>
               <AlertMessageDialog showIcon="warning" alertTitle="Cancel process" buttonText="Cancel" message="Are you sure you want to cancel this process? All unsaved changes will be lost" onYes={() => { navigate("/main"); }}></AlertMessageDialog>
-              {(isLoggedInUserInRole([ApplicationRoles.Supervisor]) ) &&
+              {(isLoggedInUserInRole([ApplicationRoles.Reviewer]) ) &&
                 <AlertMessageDialog showIcon="warning" buttonDisabled={ !areAllScoreSelected() } alertTitle="Approve Evaluation" buttonText="Approve" message="Are you sure you want to approve this evaluation?" onYes={() => approveEvaluation()}></AlertMessageDialog>
               }
             </ButtonGroup>

--- a/src/reactapp/src/pages/Main.js
+++ b/src/reactapp/src/pages/Main.js
@@ -31,7 +31,7 @@ export default function EvaluationTable() {
   const headers = [
     { name: 'Evaluation', dataField: 'performanceEvaluationTitle', sortable: true, visible: true, link: { url: '/evaluation/', dataField: 'performanceEvaluationRatingId' } },
     { name: 'Candidate', dataField: 'reviewedCandidateName', sortable: true, visible: true },
-    { name: 'Evaluator', dataField: 'evaluatorName', sortable: true, visible: isLoggedInUserInRole([ApplicationRoles.Supervisor]) },
+    { name: 'Evaluator', dataField: 'evaluatorName', sortable: true, visible: isLoggedInUserInRole([ApplicationRoles.Reviewer]) },
     { name: 'Date', dataField: 'actualDate', sortable: true, visible: true, format: value => new Date(value).toLocaleDateString() },
     { name: 'Status', dataField: 'evaluationStatus', sortable: true, visible: true },
   ];
@@ -72,7 +72,7 @@ export default function EvaluationTable() {
     try {
       let response;
 
-      if (isLoggedInUserInRole([ApplicationRoles.Supervisor])) {
+      if (isLoggedInUserInRole([ApplicationRoles.Reviewer])) {
         response = await get('/api/EvaluationRating/');
       } else {
         response = await get(`/api/EvaluationRating/${userId}`);

--- a/src/webapi/Controllers/CandidateController.cs
+++ b/src/webapi/Controllers/CandidateController.cs
@@ -13,7 +13,7 @@ using OpenIddict.Validation.AspNetCore;
 
 namespace eppeta.webapi.Controllers
 {
-    [Authorize(AuthenticationSchemes = OpenIddictValidationAspNetCoreDefaults.AuthenticationScheme, Roles = $"{Roles.Supervisor}, {Roles.MentorTeacher}")]
+    [Authorize(AuthenticationSchemes = OpenIddictValidationAspNetCoreDefaults.AuthenticationScheme, Roles = $"{Roles.Reviewer}, {Roles.Evaluator}")]
     [Route("api/[controller]")]
     [ApiController]
     public class CandidateController : ControllerBase

--- a/src/webapi/Controllers/CandidateController.cs
+++ b/src/webapi/Controllers/CandidateController.cs
@@ -5,11 +5,15 @@
 
 using eppeta.webapi.DTO;
 using eppeta.webapi.Evaluations.Data;
+using eppeta.webapi.Identity.Models;
 using eppeta.webapi.Service;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using OpenIddict.Validation.AspNetCore;
 
 namespace eppeta.webapi.Controllers
 {
+    [Authorize(AuthenticationSchemes = OpenIddictValidationAspNetCoreDefaults.AuthenticationScheme, Roles = $"{Roles.Supervisor}, {Roles.MentorTeacher}")]
     [Route("api/[controller]")]
     [ApiController]
     public class CandidateController : ControllerBase

--- a/src/webapi/Controllers/EvaluationController.cs
+++ b/src/webapi/Controllers/EvaluationController.cs
@@ -6,13 +6,17 @@
 using eppeta.webapi.DTO;
 using eppeta.webapi.Evaluations.Data;
 using eppeta.webapi.Evaluations.Models;
+using eppeta.webapi.Identity.Models;
 using eppeta.webapi.Service;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Caching.Memory;
+using OpenIddict.Validation.AspNetCore;
 using System.Linq.Dynamic.Core;
 
 namespace eppeta.webapi.Controllers;
 
+[Authorize(AuthenticationSchemes = OpenIddictValidationAspNetCoreDefaults.AuthenticationScheme, Roles = $"{Roles.Supervisor}, {Roles.MentorTeacher}")]
 [ApiController]
 [Route("api/[controller]")]
 public class EvaluationController : ControllerBase

--- a/src/webapi/Controllers/EvaluationController.cs
+++ b/src/webapi/Controllers/EvaluationController.cs
@@ -16,7 +16,7 @@ using System.Linq.Dynamic.Core;
 
 namespace eppeta.webapi.Controllers;
 
-[Authorize(AuthenticationSchemes = OpenIddictValidationAspNetCoreDefaults.AuthenticationScheme, Roles = $"{Roles.Supervisor}, {Roles.MentorTeacher}")]
+[Authorize(AuthenticationSchemes = OpenIddictValidationAspNetCoreDefaults.AuthenticationScheme, Roles = $"{Roles.Reviewer}, {Roles.Evaluator}")]
 [ApiController]
 [Route("api/[controller]")]
 public class EvaluationController : ControllerBase

--- a/src/webapi/Controllers/EvaluationRatingController.cs
+++ b/src/webapi/Controllers/EvaluationRatingController.cs
@@ -10,16 +10,18 @@ using eppeta.webapi.Evaluations.Models;
 using eppeta.webapi.Identity.Models;
 using eppeta.webapi.Mapping;
 using eppeta.webapi.Service;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using OpenIddict.Abstractions;
 using System.Data;
+using OpenIddict.Validation.AspNetCore;
 
 // For more information on enabling Web API for empty projects, visit https://go.microsoft.com/fwlink/?LinkID=397860
 
 namespace eppeta.webapi.Controllers
 {
-    //    [Authorize(AuthenticationSchemes = OpenIddictValidationAspNetCoreDefaults.AuthenticationScheme)]
+    [Authorize(AuthenticationSchemes = OpenIddictValidationAspNetCoreDefaults.AuthenticationScheme, Roles = $"{Roles.Supervisor}, {Roles.MentorTeacher}")]
     [Route("api/[controller]")]
     [ApiController]
     public class EvaluationRatingController : ControllerBase
@@ -106,7 +108,7 @@ namespace eppeta.webapi.Controllers
                 { typeof(EvaluationObjectiveRatingForUpdate).Name, new List<int>{ } },
                 { typeof(EvaluationElementRatingResultForUpdate).Name, new List<int>{ } },
             };
-            
+
             DateTime newEvaluationDate = evaluationResult.StartDateTime ?? DateTime.UtcNow;
             DateTime currentEvaluationDate = evaluationResult.StartDateTime ?? DateTime.UtcNow;
 
@@ -238,6 +240,7 @@ namespace eppeta.webapi.Controllers
 
         }
 
+        [Authorize(AuthenticationSchemes = OpenIddictValidationAspNetCoreDefaults.AuthenticationScheme, Roles = $"{Roles.Supervisor}")]
         [HttpPost]
         [Route("Approve")]
         [ProducesResponseType(StatusCodes.Status200OK)]

--- a/src/webapi/Controllers/EvaluationRatingController.cs
+++ b/src/webapi/Controllers/EvaluationRatingController.cs
@@ -21,7 +21,7 @@ using OpenIddict.Validation.AspNetCore;
 
 namespace eppeta.webapi.Controllers
 {
-    [Authorize(AuthenticationSchemes = OpenIddictValidationAspNetCoreDefaults.AuthenticationScheme, Roles = $"{Roles.Supervisor}, {Roles.MentorTeacher}")]
+    [Authorize(AuthenticationSchemes = OpenIddictValidationAspNetCoreDefaults.AuthenticationScheme, Roles = $"{Roles.Reviewer}, {Roles.Evaluator}")]
     [Route("api/[controller]")]
     [ApiController]
     public class EvaluationRatingController : ControllerBase
@@ -240,7 +240,7 @@ namespace eppeta.webapi.Controllers
 
         }
 
-        [Authorize(AuthenticationSchemes = OpenIddictValidationAspNetCoreDefaults.AuthenticationScheme, Roles = $"{Roles.Supervisor}")]
+        [Authorize(AuthenticationSchemes = OpenIddictValidationAspNetCoreDefaults.AuthenticationScheme, Roles = $"{Roles.Reviewer}")]
         [HttpPost]
         [Route("Approve")]
         [ProducesResponseType(StatusCodes.Status200OK)]

--- a/src/webapi/Controllers/PerformanceEvaluationController.cs
+++ b/src/webapi/Controllers/PerformanceEvaluationController.cs
@@ -5,11 +5,15 @@
 
 using eppeta.webapi.DTO;
 using eppeta.webapi.Evaluations.Data;
+using eppeta.webapi.Identity.Models;
 using eppeta.webapi.Service;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using OpenIddict.Validation.AspNetCore;
 
 namespace eppeta.webapi.Controllers;
 
+[Authorize(AuthenticationSchemes = OpenIddictValidationAspNetCoreDefaults.AuthenticationScheme, Roles = $"{Roles.Supervisor}, {Roles.MentorTeacher}")]
 [ApiController]
 [Route("api/[controller]")]
 public class PerformanceEvaluationController : ControllerBase

--- a/src/webapi/Controllers/PerformanceEvaluationController.cs
+++ b/src/webapi/Controllers/PerformanceEvaluationController.cs
@@ -13,7 +13,7 @@ using OpenIddict.Validation.AspNetCore;
 
 namespace eppeta.webapi.Controllers;
 
-[Authorize(AuthenticationSchemes = OpenIddictValidationAspNetCoreDefaults.AuthenticationScheme, Roles = $"{Roles.Supervisor}, {Roles.MentorTeacher}")]
+[Authorize(AuthenticationSchemes = OpenIddictValidationAspNetCoreDefaults.AuthenticationScheme, Roles = $"{Roles.Reviewer}, {Roles.Evaluator}")]
 [ApiController]
 [Route("api/[controller]")]
 public class PerformanceEvaluationController : ControllerBase

--- a/src/webapi/Identity/Models/Roles.cs
+++ b/src/webapi/Identity/Models/Roles.cs
@@ -9,8 +9,8 @@ namespace eppeta.webapi.Identity.Models
     {
         public const string Administrator = "Administrator";
 
-        public const string Supervisor = "Supervisor";
+        public const string Reviewer = "Reviewer";
 
-        public const string MentorTeacher = "Mentor Teacher";
+        public const string Evaluator = "Evaluator";
     }
 }


### PR DESCRIPTION
- Add Authorize annotation.
- Authorize the endpoint by roles, so, Supervisor and Mentor teacher are authorized to use the endpoints related to candidates and evaluations. 
- Add authorization for the supervisor role to the approval method.
- Rename roles:
   - Supervisor -> Reviewer
   - Mentor Teacher -> Evaluator